### PR TITLE
Subscription Cart Updates

### DIFF
--- a/pages/subscription/page-subscription.htm
+++ b/pages/subscription/page-subscription.htm
@@ -56,7 +56,7 @@ url: '/subscription/:subscriptionId'
               <p>My Subscription Status</p>
               <span class="col-md-12 custom-dropdown">
                 <select id="subscription_status" name="subscription_status">
-                {% for status in subscriptionStatuses if (status.code == 'active' or status.code == 'paused')  %}
+                {% for status in subscriptionStatuses if (status.code == 'active' or status.code == 'paused' or status.code == 'cancelled')  %}
                 <option value="{{ status.code }}" {{ option_state(status.code, subscription.status.code) }}>{{ status.name }}</option>
                 {% endfor %}
                 </select>

--- a/partials/layout-header.htm
+++ b/partials/layout-header.htm
@@ -27,7 +27,7 @@
       {% else %}
         <li><a href="{{ site_url('login') }}"><i class="fa fa-lock"></i> Login</a></li>
       {% endif %}
-      <li id="mini-cart">  {{ partial('shop-minicart-totals') }}</a></li>
+      <li id="mini-cart">  {{ partial('shop-minicart-totals') }}</li>
       {% if customer %}
         <li><a href="{{ site_url('checkout') }}">Checkout</a></li>
       {% else %}

--- a/partials/shop-cart-checkout.htm
+++ b/partials/shop-cart-checkout.htm
@@ -1,22 +1,37 @@
 {% for item in items %}
-	<div class="row" id="checkout-row">
-		<div class="col-sm-3 col-xs-12" id="cart-img" style="padding:0;">
-			<img src="{{ item.product.images.first.thumbnail('auto', 'auto') }}" alt="{{ item.product.name }}">
-		</div>
-		<div class="col-sm-9 col-xs-12" style="padding-right:0px;">
-			<a href="/product/{{ item.product.url_name }}">{{ item.product.name }}</a><br>
-			{% set options = item.optionsString() %}
-	        {% if options %}
-	            <p class="h6">{{ options|unescape }}</p>
-	        {% endif %}
-	        <p class="small">
-	        	Quantity: <span class="pull-right">
-	        		{{item.quantity}} x {% if item.product.onSale() %}<s>{{ item.product.fullPrice()|currency }}</s>{% endif %} {{ item.price()|currency }}
-	        </p>
-	        {% if item.totalDiscount() > 0 %}
-	        	<p class="small">Discount: <span class="pull-right cart-discount">- {{item.totalDiscount()|currency}}</span></p>
-	        {% endif %}
-	        <p class="small">Total: <span class="pull-right">{{ item.total()|currency }}</span></p>
-		</div>
-	</div>
+    <div class="row" id="checkout-row">
+        <div class="col-sm-3 col-xs-12" id="cart-img" style="padding:0;">
+            <img src="{{ item.product.images.first.thumbnail('auto', 'auto') }}" alt="{{ item.product.name }}">
+        </div>
+        <div class="col-sm-9 col-xs-12" style="padding-right:0px;">
+            <a href="/product/{{ item.product.url_name }}"><span style="font-weight: bold">{{ item.product.name }}</span>
+            {% set options = item.optionsString() %}
+            {% if options %}
+                - <span class="h6">{{ options|unescape }}</span>
+            {% endif %}
+            </a><br>
+            {% if item.x_billing_plan_id %}
+                <li class="list-group-item">Subscription plan: <div class="pull-right">{{ item.product.subscriptionPlans.find(item.x_billing_plan_id).name }}</div></li>
+            {% endif %}
+            <li class="list-group-item">Quantity: <div class="pull-right">{{item.quantity}} x {% if item.product.onSale() %}<s>{{ item.product.fullPrice()|currency }}</s>{% endif %} {{ item.price()|currency }}</div></li>
+            {% if item.totalDiscount() > 0 %}
+                <li class="list-group-item">Discount: <div class="pull-right">- {{item.totalDiscount()|currency}}</div></li>
+            {% endif %}
+                <li class="list-group-item">Total: <div class="pull-right">{{ item.total()|currency }}</div></li>
+            {% if item.is_trial_product %}
+                <div>
+                    <span class="h6">
+                        *This item is a Trial Product, and is only included in the first order.
+                    </span>
+                </div>
+                {% if billingPlans.find(cart_billing_plan).trial_period_enabled %}
+                <div>
+                    <span class="h6">
+                        *Trial Period lasts {{ billingPlans.find(cart_billing_plan).trial_period }} days.
+                    </span>
+                </div>
+                {% endif %}
+            {% endif %}
+        </div>
+    </div>
 {% endfor %}

--- a/partials/shop-cart-content.htm
+++ b/partials/shop-cart-content.htm
@@ -9,19 +9,6 @@
 
 </div>
 <div class="col-md-12">
-    {% if cart.x_billing_plan_id %}
-    <div class="col-md-4">
-        <p>Subscription Plan</p>
-        <span class="custom-dropdown">
-            <select id="billing_plan" class="select_option" name="billing_plan"> 
-                {% for plan in billingPlans %}
-                    <option value="{{ plan.id }}" {{ option_state(plan.id, cart_billing_plan) }}>{{ plan.name }}</option>
-                {% endfor %}
-            </select>
-        </span>
-    </div>
-    {% endif %}
-
     <div class="col-md-8 col-sm-12 col-xs-12" id="summary">
         {{ partial('shop-checkout-totals') }}
         <input type="text" class="form-control" id="coupon-code" name="coupon" placeholder="Coupon Code" value="{{ coupon_code }}" /><br><br>

--- a/partials/shop-cart-items.htm
+++ b/partials/shop-cart-items.htm
@@ -71,7 +71,7 @@
                         *This item is a Trial Product, and is only included in the first order.
                     </span>
                 </div>
-                {% if billingPlans.find(cart_billing_plan).trial_period %}
+                {% if billingPlans.find(cart_billing_plan).trial_period_enabled %}
                 <div>
                     <span class="h6">
                         *Trial Period lasts {{ billingPlans.find(cart_billing_plan).trial_period }} days.

--- a/partials/shop-cart-items.htm
+++ b/partials/shop-cart-items.htm
@@ -1,106 +1,122 @@
 {% if cart.listitems|length %}
-	{% if cart.getDiscountTotal() > 0 %}
-		<div class="row content" id="cart-items">
-			<div class="col-sm-5 col-xs-7">
-				Product
-			</div>
-			<div class="col-sm-1 col-xs-2">
-				Quantity
-			</div>
-			<div class="col-sm-2 cart-price">
-				Unit Price
-			</div>
-			<div class="col-sm-2 cart-price">
-				Discount
-			</div>
-			<div class="col-sm-2 col-xs-3">
-				Item Total
-			</div>
-		</div>
+    {% if cart.getDiscountTotal() > 0 %}
+        <div class="row content" id="cart-items">
+            <div class="col-sm-5 col-xs-7">
+                Product
+            </div>
+            <div class="col-sm-1 col-xs-2">
+                Quantity
+            </div>
+            <div class="col-sm-2 cart-price">
+                Unit Price
+            </div>
+            <div class="col-sm-2 cart-price">
+                Discount
+            </div>
+            <div class="col-sm-2 col-xs-3">
+                Item Total
+            </div>
+        </div>
 
-	{% else %}
-		<div class="row content" id="cart-items">
-			<div class="col-sm-5 col-xs-7">
-				Product
-			</div>
-			<div class="col-sm-2 col-xs-2">
-				Quantity
-			</div>
-			<div class="col-sm-3 cart-price">
-				Unit Price
-			</div>
-			<div class="col-sm-2 col-xs-3">
-				Item Total
-			</div>
-		</div>
-	{% endif %}
+    {% else %}
+        <div class="row content" id="cart-items">
+            <div class="col-sm-5 col-xs-7">
+                Product
+            </div>
+            <div class="col-sm-2 col-xs-2">
+                Quantity
+            </div>
+            <div class="col-sm-3 cart-price">
+                Unit Price
+            </div>
+            <div class="col-sm-2 col-xs-3">
+                Item Total
+            </div>
+        </div>
+    {% endif %}
 {% else %}
-	<p>There are no Items in your cart!</p>
+    <p>There are no Items in your cart!</p>
 {% endif %}
 
 {% for item in items %}
-	<div class="row" id="cart-row">
-		<div class="col-sm-2 cart-img">
-			<img src="{{ item.product.images.first.thumbnail('auto', 'auto') }}" alt="{{ item.product.name }}">
-		</div>
+    <div class="row" id="cart-row">
+        <div class="col-sm-2 cart-img">
+            <img src="{{ item.product.images.first.thumbnail('auto', 'auto') }}" alt="{{ item.product.name }}">
+        </div>
 
-		<div class="col-sm-3 col-xs-7">
-			<a href="/product/{{ item.product.url_name }}">{{ item.product.name }}</a>
-			{% set options = item.optionsString() %}
-			{% if options %}
-				<p class="h6">{{ options|unescape }}</p>
-			{% endif %}
-		</div>
-		{% if cart.getDiscountTotal() > 0 %}
-			<div class="col-sm-1 col-xs-2">
-				{% if edit_cart %}
-					<input type="text" id="quantity" name="item_quantity[{{ item.key }}]" value="{{ item.quantity }}">
-				{% else %}
-					{{item.quantity}}
-				{% endif %}
-			</div>
-			<div class="col-sm-2 cart-price">
-				<p>
-					{% if item.product.onSale() %}
-		                <span><s>{{ item.product.fullPrice()|currency }}</s></span>
-		            {% endif %}
-		            <span>{{ item.price()|currency }}</span>
-	            </p>
-			</div>
-			<div class="col-sm-2 cart-price">
-				<p><span class="cart-discount"> - {{item.totalDiscount()|currency}} </span></p>
-			</div>
-		{% else %}
-			<div class="col-sm-2 col-xs-2">
-				{% if edit_cart %}
-					<input type="text" id="quantity" name="item_quantity[{{ item.key }}]" value="{{ item.quantity }}">
-				{% else %}
-					{{item.quantity}}
-				{% endif %}
-			</div>
-			<div class="col-sm-3 cart-price">
-				<div><p>
-					{% if item.product.onSale() %}
-		                <span><s>{{ item.product.fullPrice()|currency }}</s></span>
-		            {% endif %}
-		            <span>{{ item.price()|currency }}</span>
-	            </p></div>
-			</div>
-		{% endif %}
-		<div class="col-sm-2 col-xs-3">
-			<div class="col-sm-6 col-xs-10">
-				<p>{{ item.total()|currency }}</p>
-			</div>
-			<div class="col-sm-6 col-xs-2">
-				{% if edit_cart %}
-					<a id="item-close" href="#close" 
-					data-ajax-handler="shop:cart" 
-					{# data-ajax-confirm="Do you really want to remove this item from the cart?" #}
-					data-ajax-update="#cart-content=shop-cart-content, #mini-cart=shop-minicart-totals"
-					data-ajax-extra-fields="delete_item='{{ item.key }}'"
-					><i class="fa fa-times" id="remove-cart-item"></i></a>
-				{% endif %}
-			</div>
-		</div>
-	</div>
+        <div class="col-sm-3 col-xs-7">
+            {% set options = item.optionsString() %}
+            <a href="/product/{{ item.product.url_name }}">{{ item.product.name }}
+            {% if options %}
+                 - <span class="h6">{{ options|unescape }}</span>
+            {% endif %}
+            </a>
+            {% if cart_billing_plan %}
+            <div style="margin-top: 10px;">
+                <span class="custom-dropdown option-dropdown" style="width: 100%">
+                    <select id="billing_plan" name="item_subscription_plan[{{ item.key }}]" 
+                    data-ajax-handler="shop:cart" 
+                    data-ajax-update="#cart-content=shop-cart-content, #mini-cart=shop-minicart-totals"> 
+                        <option value="">No subscription</option>
+                        {% for plan in billingPlans %}
+                            <option value="{{ plan.id }}" {{ option_state(plan.id, item.x_billing_plan_id) }}>{{ plan.name }}</option>
+                        {% endfor %}
+                    </select>
+                </span>
+            </div>
+            {% endif %}
+        </div>
+
+        {% if cart.getDiscountTotal() > 0 %}
+            <div class="col-sm-1 col-xs-2">
+                {% if edit_cart %}
+                    <input type="text" id="quantity" name="item_quantity[{{ item.key }}]" value="{{ item.quantity }}">
+                {% else %}
+                    {{item.quantity}}
+                {% endif %}
+            </div>
+            <div class="col-sm-2 cart-price">
+                <p>
+                    {% if item.product.onSale() %}
+                        <span><s>{{ item.product.fullPrice()|currency }}</s></span>
+                    {% endif %}
+                    <span>{{ item.price()|currency }}</span>
+                </p>
+            </div>
+            <div class="col-sm-2 cart-price">
+                <p><span class="cart-discount"> - {{item.totalDiscount()|currency}} </span></p>
+            </div>
+        {% else %}
+            <div class="col-sm-2 col-xs-2">
+                {% if edit_cart %}
+                    <input type="text" id="quantity" name="item_quantity[{{ item.key }}]" value="{{ item.quantity }}">
+                {% else %}
+                    {{item.quantity}}
+                {% endif %}
+            </div>
+            <div class="col-sm-3 cart-price">
+                <div><p>
+                    {% if item.product.onSale() %}
+                        <span><s>{{ item.product.fullPrice()|currency }}</s></span>
+                    {% endif %}
+                    <span>{{ item.price()|currency }}</span>
+                </p></div>
+            </div>
+        {% endif %}
+        <div class="col-sm-2 col-xs-3">
+            <div class="col-sm-6 col-xs-10">
+                <p>{{ item.total()|currency }}</p>
+            </div>
+            <div class="col-sm-6 col-xs-2">
+                {% if edit_cart %}
+                    <a id="item-close" href="#close" 
+                    data-ajax-handler="shop:cart" 
+                    {# data-ajax-confirm="Do you really want to remove this item from the cart?" #}
+                    data-ajax-update="#cart-content=shop-cart-content, #mini-cart=shop-minicart-totals"
+                    data-ajax-extra-fields="delete_item='{{ item.key }}'"
+                    ><i class="fa fa-times" id="remove-cart-item"></i></a>
+                {% endif %}
+            </div>
+        </div>
+    </div>
 {% endfor %}

--- a/partials/shop-cart-items.htm
+++ b/partials/shop-cart-items.htm
@@ -58,12 +58,26 @@
                     data-ajax-handler="shop:cart" 
                     data-ajax-update="#cart-content=shop-cart-content, #mini-cart=shop-minicart-totals"> 
                         <option value="">No subscription</option>
-                        {% for plan in billingPlans %}
+                        {% for plan in item.product.subscriptionPlans %}
                             <option value="{{ plan.id }}" {{ option_state(plan.id, item.x_billing_plan_id) }}>{{ plan.name }}</option>
                         {% endfor %}
                     </select>
                 </span>
             </div>
+            {% endif %}
+            {% if item.is_trial_product %}
+                <div>
+                    <span class="h6">
+                        *This item is a Trial Product, and is only included in the first order.
+                    </span>
+                </div>
+                {% if billingPlans.find(cart_billing_plan).trial_period %}
+                <div>
+                    <span class="h6">
+                        *Trial Period lasts {{ billingPlans.find(cart_billing_plan).trial_period }} days.
+                    </span>       
+                </div>
+                {% endif %}
             {% endif %}
         </div>
 

--- a/partials/shop-product.htm
+++ b/partials/shop-product.htm
@@ -37,81 +37,28 @@
 
             <div class="col-md-12">
                 <div class="col-md-3">
-                    <p class="title" for="billing_plan">Quantity</p>
+                    <p class="title" for="quantity">Quantity</p>
                     <input class="product-qty" type="text" value="{{ quantity|default("1") }}" name="quantity"/>
                 </div>
             </div>
 
-            {% set isSubCart = 0 %}
-            {% if cart.listitems|length %}
-                {# Items in cart #}
-                {% for item in cart.listitems %}
-                    {% if item.product.productType.name == 'Subscription' %}
-                        {% set isSubCart = 1 %}
-                    {% endif %}
-                {% endfor %}
-            {% endif %}
-
-            {% if product.productType.name == 'Subscription' %}
+            {% if product.subscriptionPlans|length %}
                 <div class="product-options col-md-12">
-                    <p class="title" for="billing_plan">Billing plan</p>
-                    {# Can't change billing plan once set #}
-                    {% if isSubCart %}
-                        <div class="disabled-custom-dropdown">
-                            {% for plan in billingPlans %}
-                                {% if plan.id == cart.x_billing_plan_id %}
-                                    <select style="display: none" id="billing_plan" class="select_option" name="billing_plan"> 
-                                        <option value="{{ plan.id }}" {{ option_state(plan.id, cart_billing_plan) }}>{{ plan.name }}</option>
-                                    </select>
-                                    {{ plan.name }}
-                                {% endif %}
-                            {% endfor %}
-                        </div>
-                        <p><strong>It is not possible to checkout multiple subscriptions with different billing plans. In order to change your billing plan go to your <a href="{{ root_url('/cart') }}">shopping cart</a>.</strong></p>
-                    {% else %}
-                        <span class="col-md-12 custom-dropdown option-dropdown">
-                        <select id="billing_plan" class="select_option" name="billing_plan"> 
-                            {% for plan in billingPlans %}
+                    <p class="title" for="product_billing_plan">Billing plan</p>
+                        <span class="col-md-12 custom-dropdown option-dropdown" style="width: 100%">
+                        <select id="product_billing_plan" class="select_option" name="product_billing_plan"> 
+                            <option value="">No subscription</option>
+                            {% for plan in product.subscriptionPlans %}
                                 <option value="{{ plan.id }}" {{ option_state(plan.id, cart_billing_plan) }}>{{ plan.name }}</option>
                             {% endfor %}
                         </select>
                         </span>
-                    {% endif %}
                 </div>
             {% endif %}
 
             <div class="add-cart-holder form-group col-md-12">
                 {{ flash() }}
-                
-                {% if cart.listitems|length %}
-                    {% if isSubCart %}
-                        {# Subscriptions in cart #}
-                        {% if product.productType.name == 'Subscription' %}
-                            {# Product is subscription, check billing plan selected #}
-                            <input type="hidden" name="redirect" value="/cart"/>
-                            <a class="btn btn-important btn-add-cart " href="{{ root_url('/cart') }}" data-ajax-handler="shop:onAddToCart" data-ajax-extra-fields="subscribe=0, noFlash=1">Add to Cart</a>
-                        {% else %}
-                            {# Sub in cart, Product non subscription #}
-                            <p><strong>It is not possible to purchase non-subscription and subscription products at the same time. In order to order this product, please remove all subscription products from your <a href="{{ root_url('/cart') }}">shopping cart</a>.</strong></p>
-                        {% endif %}
-                    {% else %}
-                        {# No subscriptions in cart #}
-                        {% if product.productType.name == 'Subscription' %}
-                            {# Non-sub cart, Product is subscription #}
-                            <p><strong>It is not possible to purchase non-subscription and subscription products at the same time. In order to order this product, please remove all non-subscription items from your <a href="{{ root_url('/cart') }}">shopping cart</a>.</strong></p>
-                        {% else %}
-                            {# Product is non subscription #}
-                            <a class="btn btn-important btn-add-cart " href="#" data-ajax-handler="shop:onAddToCart" data-ajax-update="#shop-product=shop-product, #mini-cart=shop-minicart-totals" data-ajax-extra-fields="subscribe=0, noFlash=0">Add to Cart</a>
-                        {% endif %}
-                    {% endif %}
-                {% elseif product.productType.name == 'Subscription' %}
-                    {# Empty cart, product is subscription #}
-                    <input type="hidden" name="redirect" value="/cart"/>
-                    <a class="btn btn-important btn-add-cart " href="{{ root_url('/cart') }}" data-ajax-handler="shop:onAddToCart" data-ajax-extra-fields="subscribe=1, noFlash=1">Add to Cart</a>
-                {% else %}
-                    {# Empty cart, product is non subscription #}
-                    <a class="btn btn-important btn-add-cart " href="#" data-ajax-handler="shop:onAddToCart" data-ajax-update="#shop-product=shop-product, #mini-cart=shop-minicart-totals" data-ajax-extra-fields="subscribe=0, noFlash=0, emptyCart=1">Add to Cart</a>
-                {% endif %}
+                <a class="btn btn-important btn-add-cart " href="{{ root_url('/cart') }}" data-ajax-handler="shop:onAddToCart" data-ajax-update="#mini-cart=shop-minicart-totals, #shop-product=shop-product">Add to Cart</a>
             </div>
         {% else %}
             <div class="not-available">


### PR DESCRIPTION
## Changes
1. Updates product page to have 2 settings - with or without subscription plans:
  - If product allows for no-subscription, the option is still there when adding to cart. Otherwise if it's subscription-only, this is hidden and only subscription plans are allowed chosen:
    ![men_s_t-shirt_of_the_month___coffree](https://user-images.githubusercontent.com/14319209/29886165-071caaca-8d6e-11e7-94d6-d905debe0fed.png)
2. Updates cart page to show item-level subscription plans if they exist:
  ![cart___coffree](https://user-images.githubusercontent.com/14319209/29886142-f26c6b38-8d6d-11e7-8a54-8303d063ad5d.png)
3. If item-level subscription plans don't exist, these aren't shown:
  ![cart___coffree](https://user-images.githubusercontent.com/14319209/29886218-35a516ca-8d6e-11e7-8f8a-60552d6387a8.png)
4. Trial products have a simple message denoting that they are a trial product to be included in the first order only:
  ![cart___coffree](https://user-images.githubusercontent.com/14319209/29886420-d9462e04-8d6e-11e7-83ee-52f75078ed07.png)
5. If a trial period exists:
  ![cart___coffree](https://user-images.githubusercontent.com/14319209/29886605-7c343ad4-8d6f-11e7-9ff9-caac97d1aae9.png)
6. New Discount is included in calculations already
7. Updated old checkout item visuals, as the rows were quite spread apart and hard to read:
  - BEFORE:
  ![checkout___coffree](https://user-images.githubusercontent.com/14319209/29886838-50c5f6d4-8d70-11e7-8ec8-3eeb6155dfd1.png)
  - AFTER:
  ![checkout___coffree](https://user-images.githubusercontent.com/14319209/29887647-f28d5b5e-8d72-11e7-8fcb-64ee3c0fdb51.png)
8. Added "Cancelled" option to customize subscription page.


## Test Checklist
- [x] Above new visuals should look good in mobile sizes
- [x] Checkout regression on non-subscription and subscription carts
- [x] Adding product regression on non-subscription and subscription carts