### PR TITLE
Item Plan dropdown and Class Update

### DIFF
--- a/partials/shop-cart-items.htm
+++ b/partials/shop-cart-items.htm
@@ -51,7 +51,7 @@
                  - <span class="h6">{{ options|unescape }}</span>
             {% endif %}
             </a>
-            {% if cart_billing_plan %}
+            {% if cart_billing_plan and (item.product.subscriptionPlans.count > 0) %}
             <div style="margin-top: 10px;">
                 <span class="custom-dropdown option-dropdown" style="width: 100%">
                     <select id="billing_plan" name="item_subscription_plan[{{ item.key }}]" 

--- a/partials/shop-cart-items.htm
+++ b/partials/shop-cart-items.htm
@@ -66,13 +66,13 @@
             </div>
             {% endif %}
             {% if item.is_trial_product %}
-                <div>
+                <div class="trial-product-message">
                     <span class="h6">
                         *This item is a Trial Product, and is only included in the first order.
                     </span>
                 </div>
                 {% if billingPlans.find(cart_billing_plan).trial_period_enabled %}
-                <div>
+                <div class="trial-period-message">
                     <span class="h6">
                         *Trial Period lasts {{ billingPlans.find(cart_billing_plan).trial_period }} days.
                     </span>       


### PR DESCRIPTION
## Changes
1. Only displays subscription dropdown if the subscription options exist for item plans
2. Adds classes to trial product *messages in cart page

Example: Graphic Lemons has no Plans associated to the product:

![cart___coffree](https://user-images.githubusercontent.com/14319209/30191577-85147924-93f6-11e7-88ee-6dabe4fc9d7f.png)

## Test Checklist
- [ ] Verify list populates for products with subscription plans associated
- [ ] Verify list doesn't populate for products with NO subscription plans associated